### PR TITLE
fix: Subpage Consistency & CTA Link Standardization

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -522,3 +522,32 @@ pre code {
   font-family: var(--font-mono);
   font-size: 0.85rem;
 }
+
+// Subpage Legacy Compatibility
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2px;
+  background: var(--border-color);
+  border: 2px solid var(--border-color);
+  margin: 2rem 0;
+}
+
+.card {
+  background: var(--primary-bg);
+  padding: 2.5rem;
+  transition: all var(--transition-fast);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.card:hover {
+  background: var(--card-hover-bg);
+}
+
+.card .button {
+  margin-top: auto;
+  align-self: flex-start;
+}

--- a/index.markdown
+++ b/index.markdown
@@ -46,7 +46,7 @@ layout: default
             Connects securely via remote WebSocket gateways to execute infrastructure deployments and terminal commands without hallucinations.
           </p>
           <div class="mt-2">
-            <a href="https://github.com/VitruvianSoftware/nexus-agent" class="button btn-accent">View Documentation</a>
+            <a href="https://github.com/VitruvianSoftware/nexus-agent" class="button btn-accent">Explore Project</a>
           </div>
         </div>
         <div class="bento-number">01</div>
@@ -61,7 +61,7 @@ layout: default
             Standardize your repository initialization. Eradicate configuration drift across teams through docker-tethered sandboxes and rigorous git-flow hooks.
           </p>
           <div class="mt-2">
-            <a href="https://github.com/VitruvianSoftware/devx" class="button">brew install devx</a>
+            <a href="https://github.com/VitruvianSoftware/devx" class="button">Explore Project</a>
           </div>
         </div>
         <div class="bento-number">02</div>
@@ -76,7 +76,7 @@ layout: default
             Automated provisioning protocol for multi-node Kubernetes (K3s) edge clusters over bare metal via Lima VZ. Deterministic container orchestration locally.
           </p>
           <div style="margin-top: clamp(2rem, 10vh, 5rem);">
-            <a href="https://github.com/VitruvianSoftware/homelab" class="button">Inspect Matrix</a>
+            <a href="https://github.com/VitruvianSoftware/homelab" class="button">Explore Project</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Restored the legacy card layout wrapper classes with brutalist aesthetic tokens to ensure subpages (Tech Stack, Blog, Projects) look identical to the bento-grid landing page. Standardized CTA button text across the homepage.