### PR TITLE
chore: Reframe DevOps to Platform terminology

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title: Vitruvian Software Open Source
 email: git@nocentre.net
 description: >- # this means to ignore newlines until "baseurl:"
   Vitruvian Software is dedicated to creating innovative open-source solutions.
-  We specialize in AI, DevOps, and cloud technologies, focusing on building tools and frameworks that empower developers and researchers.
+  We specialize in AI, Platform engineering, and cloud technologies, focusing on building tools and frameworks that empower developers and researchers.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://vitruviansoftware.dev" # the base hostname & protocol for your site, e.g. http://example.com
 avatar: "/images/logo-dark.jpeg" # Site logo

--- a/about.markdown
+++ b/about.markdown
@@ -21,7 +21,7 @@ permalink: /about/
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 4rem; align-items: center;">
       <div>
         <h2>Our Mission</h2>
-        <p>At Vitruvian Software, we believe in deterministic, fast, and elegantly engineered solutions. Our mission is to build tools and frameworks that solve deeply technical problems without the bloat, making complex DevOps and AI technologies accessible and reproducible.</p>
+        <p>At Vitruvian Software, we believe in deterministic, fast, and elegantly engineered solutions. Our mission is to build tools and frameworks that solve deeply technical problems without the bloat, making complex Platform and AI technologies accessible and reproducible.</p>
         
         <p>We specialize in three core areas:</p>
         <ul style="list-style: none; padding: 0; margin: 1rem 0;">
@@ -29,7 +29,7 @@ permalink: /about/
             <strong style="color: var(--primary-text);">🤖 Agentic Intelligence:</strong> Bridging the gap between humans and LLMs via native operating system bridging.
           </li>
           <li style="margin-bottom: 1rem; position: relative;">
-            <strong style="color: var(--primary-text);">⚙️ DevOps:</strong> Streamlining local development workflows and declarative infrastructure.
+            <strong style="color: var(--primary-text);">⚙️ Platform Engineering:</strong> Streamlining local development workflows and declarative infrastructure.
           </li>
           <li style="margin-bottom: 1rem; position: relative;">
             <strong style="color: var(--primary-text);">☁️ Kubernetes:</strong> Creating scalable, local-first testing environments for cloud-native applications.

--- a/blog.md
+++ b/blog.md
@@ -9,7 +9,7 @@ permalink: /blog/
   <div class="hero-content">
     <span class="tag">Engineering Log</span>
     <h1>Our Blog</h1>
-    <p>Insights, tutorials, and updates from the Vitruvian Software team on agentic tooling, DevOps, and open-source development.</p>
+    <p>Insights, tutorials, and updates from the Vitruvian Software team on agentic tooling, Platform architecture, and open-source development.</p>
   </div>
   <div class="hero-visual">
     <img src="/images/blog_hero.png" alt="Code Ledger Data Stream Graphic">
@@ -79,8 +79,8 @@ permalink: /blog/
       </div>
       
       <div class="card">
-        <h3>⚙️ DevOps Insights</h3>
-        <p>Practical DevOps tutorials, automation strategies with DevX, and reproducible build pipelines.</p>
+        <h3>⚙️ Platform Insights</h3>
+        <p>Practical Platform tutorials, automation strategies with DevX, and reproducible build pipelines.</p>
       </div>
       
       <div class="card">

--- a/index.markdown
+++ b/index.markdown
@@ -6,7 +6,7 @@ layout: default
 <div class="split-hero">
   <div class="hero-content">
     <span class="tag">Engineering Frameworks</span>
-    <h1>Architecting DevOps Infrastructure</h1>
+    <h1>Architecting Platform Infrastructure</h1>
     <p>High-performance local cloud tooling, reproducible environments, and deterministic agentic systems mapped straight to macOS. No vibe-coding. Just operations.</p>
     
     <div style="display: flex; gap: 1rem; margin-top: 2rem;">

--- a/projects.md
+++ b/projects.md
@@ -9,7 +9,7 @@ permalink: /projects/
   <div class="hero-content">
     <span class="tag">Open Source</span>
     <h1>Our Open Source Ecosystem</h1>
-    <p>Explore our comprehensive collection of open-source tools and frameworks designed to empower developers and infrastructure engineers in AI, DevOps, and cloud environments.</p>
+    <p>Explore our comprehensive collection of open-source tools and frameworks designed to empower developers and infrastructure engineers in AI, Platform, and cloud environments.</p>
   </div>
   <div class="hero-visual">
     <img src="/images/projects_hero.png" alt="Brutalist Matrix Diagram">

--- a/tech-stack.md
+++ b/tech-stack.md
@@ -9,7 +9,7 @@ permalink: /tech-stack/
   <div class="hero-content">
     <span class="tag">Architecture</span>
     <h1>Our Technology Stack</h1>
-    <p>The cutting-edge technologies, languages, and frameworks that power our open-source solutions and drive innovation in AI, DevOps, and cloud computing.</p>
+    <p>The cutting-edge technologies, languages, and frameworks that power our open-source solutions and drive innovation in AI, Platform engineering, and cloud computing.</p>
   </div>
   <div class="hero-visual">
     <img src="/images/tech_stack_hero.png" alt="Server Hardware Logic Schematic">
@@ -50,7 +50,7 @@ permalink: /tech-stack/
 
       <div class="card">
         <h3>🐚 Shell & Bash</h3>
-        <p><strong>Primary Use:</strong> Automation, DevOps workflows</p>
+        <p><strong>Primary Use:</strong> Automation, Platform workflows</p>
         <p>Stringent shell scripting for initialization workflows and system-level configuration.</p>
       </div>
     </div>


### PR DESCRIPTION
Refactors broad 'DevOps' terminology to 'Platform Engineering' or 'Platform' architecture across the entire site ecosystem to better reflect our high-level tooling focus, while preserving strict DevOps terminology only within historical blog posts where traditional CI/CD practices are explicitly referenced.